### PR TITLE
Fix undefined variable in AWS SMS notification

### DIFF
--- a/sensor-alerts/aws-notification.js
+++ b/sensor-alerts/aws-notification.js
@@ -9,7 +9,7 @@ const awsConfig = {
 };
 
 //Send SMS via AWS SNS.
-async function sendSMS(message) {
+async function sendSMS(message, currentDt) {
   if (process.env.ENABLE_SMS_ALERTS === "true") {
     const smsMessage = {
       message: message,
@@ -23,7 +23,8 @@ async function sendSMS(message) {
 
     sendMsg(awsConfig, smsMessage)
       .then(data => {
-        console.log("Message sent at: " + currentDt);
+        const timestamp = currentDt || Date.now();
+        console.log("Message sent at: " + timestamp);
       })
       .catch(err => {
         console.log("Error occured - " + err);
@@ -52,7 +53,7 @@ async function sendEmail(location, message) {
 }
 
 async function sendNotification(notificationDetails) {
-  sendSMS(notificationDetails.message);
+  sendSMS(notificationDetails.message, notificationDetails.currentDt);
   sendEmail(notificationDetails.location, notificationDetails.message);
   await connections.asyncRedisClient.set(
     notificationDetails.userid,

--- a/sensor-alerts/package.json
+++ b/sensor-alerts/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test.js",
     "dev": "nodemon index.js",
     "start": "node index.js"
   },

--- a/sensor-alerts/test.js
+++ b/sensor-alerts/test.js
@@ -1,0 +1,45 @@
+const assert = require('assert');
+const Module = require('module');
+
+const originalRequire = Module.prototype.require;
+let sendMsgCalled = false;
+let redisSetCalled = false;
+
+Module.prototype.require = function(request) {
+  if (request === 'aws-sns-sms') {
+    return function(config, msg) {
+      sendMsgCalled = true;
+      return Promise.resolve();
+    };
+  }
+  if (request === './email-sender') {
+    return { sendEmailAlert: () => Promise.resolve() };
+  }
+  if (request === './connections') {
+    return { asyncRedisClient: { set: async () => { redisSetCalled = true; } } };
+  }
+  return originalRequire.apply(this, arguments);
+};
+
+const awsNotification = require('./aws-notification');
+
+Module.prototype.require = originalRequire;
+
+process.env.ENABLE_SMS_ALERTS = 'true';
+
+async function run() {
+  await awsNotification.sendNotification({
+    userid: 'user1',
+    location: 'Sydney',
+    currentDt: Date.now(),
+    message: 'Temperature alert'
+  });
+  assert(sendMsgCalled, 'sendMsg should be called');
+  assert(redisSetCalled, 'redis set should be called');
+  console.log('All tests passed');
+}
+
+run().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- handle SMS sending timestamp to avoid undefined variable
- add basic test for notification flow using stubs

## Testing
- `cd sensor-alerts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_68918b0d68e8832384b050ce71a101a1