### PR TITLE
Potential fix for code scanning alert no. 2: Reflected cross-site scripting

### DIFF
--- a/archive/sensor-listener-proxy/index.js
+++ b/archive/sensor-listener-proxy/index.js
@@ -41,7 +41,7 @@ app.post("/", (req, res) => {
     });
 
   console.log(req.body);
-  res.send(JSON.stringify(req.body));
+  res.json(req.body);
 });
 
 app.listen(8081, () => {


### PR DESCRIPTION
Potential fix for [https://github.com/sunkor/home-sensor/security/code-scanning/2](https://github.com/sunkor/home-sensor/security/code-scanning/2)

The best way to fix this problem is to ensure that the response is sent with the correct Content-Type header, specifically `application/json`, so that browsers interpret the response as JSON and do not execute any embedded scripts. In Express, this can be achieved by using `res.json(req.body)` instead of `res.send(JSON.stringify(req.body))`. The `res.json()` method automatically stringifies the object and sets the Content-Type to `application/json`. This change should be made on line 44 of `archive/sensor-listener-proxy/index.js`. No additional imports are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
