### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/archive/sensor-listener-proxy/index.js
+++ b/archive/sensor-listener-proxy/index.js
@@ -25,9 +25,7 @@ app.post("/", (req, res) => {
   if (process.env.NODE_ENV !== "production") {
     console.log({
       invokeUrl: process.env.AWS_API_ENDPOINT,
-      region: process.env.AWS_REGION,
-      accessKey: process.env.AWS_ACCESS_KEY,
-      secretKey: process.env.AWS_SECRET_KEY
+      region: process.env.AWS_REGION
     });
   }
 


### PR DESCRIPTION
Potential fix for [https://github.com/sunkor/home-sensor/security/code-scanning/1](https://github.com/sunkor/home-sensor/security/code-scanning/1)

To fix the problem, we should remove the logging of sensitive environment variables (`accessKey` and `secretKey`) from the console output. If logging is needed for debugging, only non-sensitive information (such as the endpoint and region) should be logged. The code to change is in the `app.post("/", ...)` handler, specifically the block on lines 26–31. We will modify this block to exclude `accessKey` and `secretKey` from the logged object, leaving only `invokeUrl` and `region`. No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
