### PR TITLE
Validate temperature payload before writing to InfluxDB

### DIFF
--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -36,6 +36,20 @@ app.get("/", (req, res) => {
   res.send("hello world, now lets get serious shall well?");
 });
 
+function validatePayload(req, res, next) {
+  const { temperature, location } = req.body;
+  if (
+    typeof temperature !== "number" ||
+    !Number.isFinite(temperature) ||
+    typeof location !== "string" ||
+    location.trim() === ""
+  ) {
+    res.status(400).send("Invalid payload");
+    return;
+  }
+  next();
+}
+
 function writeToInflux(req, res, next) {
   influx
     .writePoints([
@@ -107,7 +121,7 @@ async function sendNotification(req, res) {
 }
 
 //POST
-app.post("/temperature_data", writeToInflux, sendNotification);
+app.post("/temperature_data", validatePayload, writeToInflux, sendNotification);
 
 //GOOGLE ACTION.
 app.post("/fulfillment", require("./google-actions").fulfillment);


### PR DESCRIPTION
## Summary
- add middleware to validate temperature payloads for `/temperature_data`
- reject requests missing numeric `temperature` or non-empty `location`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891b41478748323803948edc42de3e7