### PR TITLE
Improve InfluxDb error handling in sensor listener

### DIFF
--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -52,7 +52,7 @@ function writeToInflux(req, res, next) {
     })
     .catch(err => {
       console.error(err);
-      res.send("Error occured while writing to InfluxDb!").status(500);
+      res.status(500).send("Error occurred while writing to InfluxDb!");
     });
 }
 


### PR DESCRIPTION
## Summary
- Correctly send 500 status when InfluxDb write fails
- Confirm middleware chain stops after sending error

## Testing
- `node test script` (simulated Influx write failure)
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891b41f83b88323aeec124127788e46