### PR TITLE
Improve sensor reading error handling

### DIFF
--- a/home-automation/sensor_read.py
+++ b/home-automation/sensor_read.py
@@ -4,6 +4,7 @@ import time
 import requests
 from datetime import datetime
 import sys
+import logging
 
 os.system('modprobe w1-gpio')
 os.system('modprobe w1-therm')
@@ -19,9 +20,8 @@ headers = {'Content-type': 'application/json',
 
 
 def read_temp_raw():
-    f = open(device_file, 'r')
-    lines = f.readlines()
-    f.close()
+    with open(device_file, "r") as f:
+        lines = f.readlines()
     return lines
 
 
@@ -50,7 +50,12 @@ def read_temp():
 while True:
     try:
         print(read_temp())
-    except:
-        e = sys.exc_info()[0]
-        print("An exception occured. %s" % e)
+    except Exception as e:
+        logging.exception("An exception occurred: %s", e)
+        if isinstance(e, requests.exceptions.RequestException):
+            logging.error("Request failed, retrying...")
+            continue
+        else:
+            logging.error("Unexpected error, exiting.")
+            break
     time.sleep(1)


### PR DESCRIPTION
## Summary
- use context manager when reading device file
- replace bare except with explicit `Exception` logging
- retry on request failures and exit on unexpected errors

## Testing
- `python -m py_compile home-automation/sensor_read.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6891b4291c548323a4b934ce89757487