### PR TITLE
Fix Celsius naming in env vars and measurements

### DIFF
--- a/data/home_sensors.json
+++ b/data/home_sensors.json
@@ -269,10 +269,10 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"temperature\") FROM \"temperature_data_in_celcius\" WHERE (\"location\" = 'study_room') AND $timeFilter",
+          "query": "SELECT last(\"temperature\") FROM \"temperature_data_in_celsius\" WHERE (\"location\" = 'study_room') AND $timeFilter",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -378,10 +378,10 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
-          "query": "SELECT last(\"temperature\") FROM \"temperature_data_in_celcius\" WHERE (\"location\" = 'Jannali') AND $timeFilter",
+          "query": "SELECT last(\"temperature\") FROM \"temperature_data_in_celsius\" WHERE (\"location\" = 'Jannali') AND $timeFilter",
           "rawQuery": true,
           "refId": "A",
           "resultFormat": "time_series",
@@ -466,7 +466,7 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "B",
@@ -499,7 +499,7 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "C",
@@ -532,7 +532,7 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -2754,7 +2754,7 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "A",
@@ -2787,7 +2787,7 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "B",
@@ -2820,7 +2820,7 @@
               "type": "time"
             }
           ],
-          "measurement": "temperature_data_in_celcius",
+          "measurement": "temperature_data_in_celsius",
           "orderByTime": "ASC",
           "policy": "default",
           "refId": "C",

--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,8 @@ runtime.
 #### sensor-listener and sensor-alerts
 - `MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION` – number of minutes to wait
   before sending another notification for the same user.
-- `TEMPERATURE_THRESHOLD_IN_CELCIUS` – temperature that triggers an alert.
+- `TEMPERATURE_THRESHOLD_IN_CELSIUS` – temperature that triggers an alert.
+  > **Note**: previously this variable was named `TEMPERATURE_THRESHOLD_IN_CELCIUS`. Update any existing environment configurations to use the corrected spelling.
 
 #### sensor-alerts (additional)
 - `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION`

--- a/sensor-alerts/index.js
+++ b/sensor-alerts/index.js
@@ -11,17 +11,17 @@ const MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION = parseInt(
   process.env.MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION,
   10
 );
-const TEMPERATURE_THRESHOLD_IN_CELCIUS = parseInt(
-  process.env.TEMPERATURE_THRESHOLD_IN_CELCIUS,
+const TEMPERATURE_THRESHOLD_IN_CELSIUS = parseInt(
+  process.env.TEMPERATURE_THRESHOLD_IN_CELSIUS,
   10
 );
 
 if (
   !Number.isFinite(MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION) ||
-  !Number.isFinite(TEMPERATURE_THRESHOLD_IN_CELCIUS)
+  !Number.isFinite(TEMPERATURE_THRESHOLD_IN_CELSIUS)
 ) {
   throw new Error(
-    "Invalid numeric environment configuration for MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION or TEMPERATURE_THRESHOLD_IN_CELCIUS"
+    "Invalid numeric environment configuration for MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION or TEMPERATURE_THRESHOLD_IN_CELSIUS"
   );
 }
 
@@ -49,10 +49,10 @@ connections.redisSubscriber.on("message", async (channel, message) => {
   }
 
   //Check threshold.
-  if (currentTemp < TEMPERATURE_THRESHOLD_IN_CELCIUS) {
+  if (currentTemp < TEMPERATURE_THRESHOLD_IN_CELSIUS) {
     if (process.env.NODE_ENV !== "production") {
       console.log(
-        `Current temperature read, ${currentTemp} does not exceed the threshold ${TEMPERATURE_THRESHOLD_IN_CELCIUS}`
+        `Current temperature read, ${currentTemp} does not exceed the threshold ${TEMPERATURE_THRESHOLD_IN_CELSIUS}`
       );
     }
     return;
@@ -91,7 +91,7 @@ connections.redisSubscriber.on("message", async (channel, message) => {
     Number.isFinite(diffInMinutes.minutes) &&
     diffInMinutes.minutes >= MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION
   ) {
-    notificationDetails.message = `Alert! Temperature threshold of ${TEMPERATURE_THRESHOLD_IN_CELCIUS} has exceeded! Current temperature in ${location} is ${currentTemp}`;
+    notificationDetails.message = `Alert! Temperature threshold of ${TEMPERATURE_THRESHOLD_IN_CELSIUS} has exceeded! Current temperature in ${location} is ${currentTemp}`;
     awsNotification.sendNotification(notificationDetails);
   } else {
     console.log("time threshold has not exceeded. Ignore!");

--- a/sensor-listener/common.js
+++ b/sensor-listener/common.js
@@ -6,7 +6,7 @@ const influx = new Influx.InfluxDB({
   database: "home_sensors_db",
   schema: [
     {
-      measurement: "temperature_data_in_celcius",
+      measurement: "temperature_data_in_celsius",
       fields: {
         temperature: Influx.FieldType.FLOAT
       },

--- a/sensor-listener/google-actions.js
+++ b/sensor-listener/google-actions.js
@@ -14,7 +14,7 @@ app.intent("get-home-room-location-temperature", async (conv, params) => {
     try {
       const result = await influx.query(
         `
-      SELECT * FROM temperature_data_in_celcius
+      SELECT * FROM temperature_data_in_celsius
       where location='study_room' GROUP BY * ORDER BY DESC LIMIT 1
     `
       );

--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -15,17 +15,17 @@ const MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION = parseInt(
   process.env.MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION,
   10
 );
-const TEMPERATURE_THRESHOLD_IN_CELCIUS = parseInt(
-  process.env.TEMPERATURE_THRESHOLD_IN_CELCIUS,
+const TEMPERATURE_THRESHOLD_IN_CELSIUS = parseInt(
+  process.env.TEMPERATURE_THRESHOLD_IN_CELSIUS,
   10
 );
 
 if (
   !Number.isFinite(MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION) ||
-  !Number.isFinite(TEMPERATURE_THRESHOLD_IN_CELCIUS)
+  !Number.isFinite(TEMPERATURE_THRESHOLD_IN_CELSIUS)
 ) {
   throw new Error(
-    "Invalid numeric environment configuration for MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION or TEMPERATURE_THRESHOLD_IN_CELCIUS"
+    "Invalid numeric environment configuration for MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION or TEMPERATURE_THRESHOLD_IN_CELSIUS"
   );
 }
 
@@ -54,7 +54,7 @@ function writeToInflux(req, res, next) {
   influx
     .writePoints([
       {
-        measurement: "temperature_data_in_celcius",
+        measurement: "temperature_data_in_celsius",
         fields: {
           temperature: req.body.temperature
         },
@@ -77,7 +77,7 @@ async function sendNotification(req, res) {
     return;
   }
 
-  if (temp < TEMPERATURE_THRESHOLD_IN_CELCIUS) {
+  if (temp < TEMPERATURE_THRESHOLD_IN_CELSIUS) {
     res.send("posted temperature data.");
     return;
   }

--- a/weather-station/index.js
+++ b/weather-station/index.js
@@ -31,7 +31,7 @@ const influx = new Influx.InfluxDB({
   database: "home_sensors_db",
   schema: [
     {
-      measurement: "temperature_data_in_celcius",
+      measurement: "temperature_data_in_celsius",
       fields: {
         temperature: Influx.FieldType.FLOAT
       },
@@ -133,14 +133,14 @@ polling.on("result", function(json) {
     influx
       .writePoints([
         {
-          measurement: "temperature_data_in_celcius",
+          measurement: "temperature_data_in_celsius",
           fields: {
             temperature: summary_data.currentTemp
           },
           tags: { location: summary_data.name }
         },
         {
-          measurement: "temperature_data_in_celcius",
+          measurement: "temperature_data_in_celsius",
           fields: {
             temperature: summary_data.feels_like
           },


### PR DESCRIPTION
## Summary
- standardize environment variable name TEMPERATURE_THRESHOLD_IN_CELSIUS
- rename InfluxDB measurement temperature_data_in_celcius to temperature_data_in_celsius
- update queries and dashboards for corrected measurement name

## Testing
- `npm test` (sensor-alerts)
- `npm test` (sensor-listener) *(fails: Error: no test specified)*
- `npm test` (weather-station) *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891b6d0c7008323a4cb2c4828e8c62b