### PR TITLE
Prevent weather API key exposure in production logs

### DIFF
--- a/weather-station/index.js
+++ b/weather-station/index.js
@@ -64,7 +64,11 @@ const influx = new Influx.InfluxDB({
 });
 
 const polling = AsyncPolling(function(end) {
-  console.log("fetching.." + url);
+  if (process.env.NODE_ENV !== "production") {
+    console.log("fetching.." + url);
+  } else {
+    console.log("fetching.." + apiEndpoint);
+  }
   fetch(url)
     .then(response => {
       if (!response.ok) {


### PR DESCRIPTION
## Summary
- Avoid logging sensitive query parameters when fetching weather data

## Testing
- `npm test`
- `NODE_ENV=production WEATHER_API_QUERY_POSTCODE=12345 WEATHER_API_QUERY_COUNTRY_CODE=US WEATHER_API_KEY=MYKEY WEATHER_API_ENDPOINT=https://example.com timeout 15 node index.js`

------
https://chatgpt.com/codex/tasks/task_e_6891b6d74e688323aee44be36da40aae