### PR TITLE
refactor: remove body-parser usage

### DIFF
--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -1,5 +1,4 @@
 const express = require("express");
-const bodyParser = require("body-parser");
 const minDate = new Date("01 Nov 1970");
 const timediff = require("timediff");
 const influx = require("./common").influx;
@@ -30,7 +29,7 @@ if (
 }
 
 const app = express();
-app.use(bodyParser.json());
+app.use(express.json());
 
 app.get("/", (req, res) => {
   res.send("hello world, now lets get serious shall well?");

--- a/sensor-listener/package.json
+++ b/sensor-listener/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "actions-on-google": "^2.12.0",
     "async-redis": "^1.1.7",
-    "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",
     "influx": "^5.5.1",


### PR DESCRIPTION
## Summary
- refactor sensor-listener to use Express' built-in JSON parser instead of body-parser
- drop unnecessary body-parser dependency

## Testing
- `npm install`
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891b6db801c832392df67eaafd333d2