### PR TITLE
Return SES sendEmail promise from email alert helper

### DIFF
--- a/sensor-alerts/email-sender.js
+++ b/sensor-alerts/email-sender.js
@@ -13,7 +13,7 @@ const sesConfig = {
 };
 
 // Handle promise's fulfilled/rejected states
-module.exports.sendEmailAlert = emailToSend => {
+module.exports.sendEmailAlert = async emailToSend => {
   // Create sendEmail params
   const params = {
     Source: emailToSend.from,
@@ -36,15 +36,14 @@ module.exports.sendEmailAlert = emailToSend => {
     }
   };
 
-  new AWS.SES(sesConfig)
-    .sendEmail(params)
-    .promise()
-    .then(res => {
-      if (process.env.NODE_ENV !== "production") {
-        console.log("email sent successfully");
-      }
-    })
-    .catch(err => {
-      console.error(err, err.stack);
-    });
+  try {
+    const res = await new AWS.SES(sesConfig).sendEmail(params).promise();
+    if (process.env.NODE_ENV !== "production") {
+      console.log("email sent successfully");
+    }
+    return res;
+  } catch (err) {
+    console.error(err, err.stack);
+    throw err;
+  }
 };


### PR DESCRIPTION
## Summary
- convert sendEmailAlert into an async function that awaits `AWS.SES().sendEmail` and rethrows errors

## Testing
- `cd sensor-alerts && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891b6e7bcf483239ac0c030d8b11584