### PR TITLE
feat: make user id configurable for sensor notifications

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,6 +41,8 @@ runtime.
 - `MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION` – number of minutes to wait
   before sending another notification for the same user.
 - `TEMPERATURE_THRESHOLD_IN_CELCIUS` – temperature that triggers an alert.
+- `DEFAULT_USER_ID` – optional fallback user ID when the request payload does
+  not specify one.
 
 #### sensor-alerts (additional)
 - `AWS_ACCESS_KEY`, `AWS_SECRET_KEY`, `AWS_REGION`


### PR DESCRIPTION
## Summary
- allow sensor-listener to read userid from request body or DEFAULT_USER_ID env var
- use dynamic userid for Redis lookups and alert publishing
- document DEFAULT_USER_ID configuration

## Testing
- `npm test` (sensor-listener) *(fails: Error: no test specified)*
- `npm test` (sensor-alerts)


------
https://chatgpt.com/codex/tasks/task_e_6891b6e3d0a08323bfa06ada71cd169d