### PR TITLE
feat: make service connections configurable

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -38,6 +38,10 @@ Create an `.env` file inside each service directory or provide the variables at
 runtime.
 
 #### sensor-listener and sensor-alerts
+- `INFLUX_HOST` – hostname for InfluxDB (default: `influxdb`).
+- `INFLUX_PORT` – port for InfluxDB (default: `8086`).
+- `REDIS_HOST` – hostname for Redis (default: `redis`).
+- `REDIS_PORT` – port for Redis (default: `6379`).
 - `MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION` – number of minutes to wait
   before sending another notification for the same user.
 - `TEMPERATURE_THRESHOLD_IN_CELSIUS` – temperature that triggers an alert.
@@ -53,6 +57,8 @@ runtime.
 - `EMAIL_LIST` – comma separated list of recipients.
 
 #### weather-station
+- `INFLUX_HOST` – hostname for InfluxDB (default: `influxdb`).
+- `INFLUX_PORT` – port for InfluxDB (default: `8086`).
 - `WEATHER_API_KEY`
 - `WEATHER_API_ENDPOINT` – e.g. `https://api.openweathermap.org/data/2.5/weather`
 - `WEATHER_API_QUERY_POSTCODE`

--- a/sensor-alerts/connections.js
+++ b/sensor-alerts/connections.js
@@ -1,8 +1,10 @@
 const asyncRedis = require("async-redis");
 
+const redisHost = process.env.REDIS_HOST || "redis";
+const redisPort = parseInt(process.env.REDIS_PORT, 10) || 6379;
 const asyncRedisClient = asyncRedis.createClient({
-  host: "redis",
-  port: 6379,
+  host: redisHost,
+  port: redisPort,
   retry_strategy: () => 1000
 });
 

--- a/sensor-listener/common.js
+++ b/sensor-listener/common.js
@@ -1,8 +1,11 @@
 const Influx = require("influx");
 const asyncRedis = require("async-redis");
 
+const influxHost = process.env.INFLUX_HOST || "influxdb";
+const influxPort = parseInt(process.env.INFLUX_PORT, 10) || 8086;
 const influx = new Influx.InfluxDB({
-  host: "influxdb",
+  host: influxHost,
+  port: influxPort,
   database: "home_sensors_db",
   schema: [
     {
@@ -16,9 +19,11 @@ const influx = new Influx.InfluxDB({
 });
 
 //Redis setup.
+const redisHost = process.env.REDIS_HOST || "redis";
+const redisPort = parseInt(process.env.REDIS_PORT, 10) || 6379;
 const asyncRedisClient = asyncRedis.createClient({
-  host: "redis",
-  port: 6379,
+  host: redisHost,
+  port: redisPort,
   retry_strategy: () => 1000
 });
 

--- a/weather-station/index.js
+++ b/weather-station/index.js
@@ -26,8 +26,11 @@ if (process.env.NODE_ENV !== "production") {
   });
 }
 
+const influxHost = process.env.INFLUX_HOST || "influxdb";
+const influxPort = parseInt(process.env.INFLUX_PORT, 10) || 8086;
 const influx = new Influx.InfluxDB({
-  host: "influxdb",
+  host: influxHost,
+  port: influxPort,
   database: "home_sensors_db",
   schema: [
     {


### PR DESCRIPTION
## Summary
- add env var support for InfluxDB and Redis connections
- document new InfluxDB/Redis host and port settings

## Testing
- `cd sensor-alerts && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891ba84fd5c8323aef328f1cb5f68ec