### PR TITLE
Add test scaffolding for sensor listener and weather station

### DIFF
--- a/sensor-listener/__tests__/sendNotification.test.js
+++ b/sensor-listener/__tests__/sendNotification.test.js
@@ -1,0 +1,40 @@
+process.env.MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION = '1';
+process.env.TEMPERATURE_THRESHOLD_IN_CELSIUS = '30';
+jest.mock('../common', () => ({
+  asyncRedisClient: { get: jest.fn() },
+  redisPublisher: { publish: jest.fn() },
+  influx: {}
+}));
+
+const { sendNotification } = require('../index');
+const { asyncRedisClient, redisPublisher } = require('../common');
+
+describe('sendNotification', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('publishes when threshold exceeded and enough time passed', async () => {
+    const now = Date.now();
+    jest.spyOn(Date, 'now').mockReturnValue(now);
+    const past = new Date(now - 2 * 60 * 1000).toISOString();
+    asyncRedisClient.get.mockResolvedValue(
+      JSON.stringify({ last_notification_time: past })
+    );
+    const req = { body: { temperature: 35, location: 'kitchen' } };
+    const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+    await sendNotification(req, res);
+    expect(redisPublisher.publish).toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith('posted temperature data.');
+    Date.now.mockRestore();
+  });
+
+  test('does not publish when temperature below threshold', async () => {
+    asyncRedisClient.get.mockResolvedValue(null);
+    const req = { body: { temperature: 20, location: 'kitchen' } };
+    const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+    await sendNotification(req, res);
+    expect(redisPublisher.publish).not.toHaveBeenCalled();
+    expect(res.send).toHaveBeenCalledWith('posted temperature data.');
+  });
+});

--- a/sensor-listener/__tests__/validatePayload.test.js
+++ b/sensor-listener/__tests__/validatePayload.test.js
@@ -1,0 +1,21 @@
+const { validatePayload } = require('../index');
+
+describe('validatePayload', () => {
+  test('rejects invalid payload', () => {
+    const req = { body: { temperature: 'hot', location: '' } };
+    const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+    const next = jest.fn();
+    validatePayload(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith('Invalid payload');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  test('accepts valid payload', () => {
+    const req = { body: { temperature: 20, location: 'kitchen' } };
+    const res = { status: jest.fn().mockReturnThis(), send: jest.fn() };
+    const next = jest.fn();
+    validatePayload(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+});

--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -125,19 +125,23 @@ app.post("/temperature_data", validatePayload, writeToInflux, sendNotification);
 //GOOGLE ACTION.
 app.post("/fulfillment", require("./google-actions").fulfillment);
 
-//Start after 10 seconds. We want InfluxDb to be ready.
-setTimeout(function() {
-  influx
-    .getDatabaseNames()
-    .then(names => {
-      if (!names.includes("home_sensors_db")) {
-        return influx.createDatabase("home_sensors_db");
-      }
-    })
-    .then(() => {
-      app.listen(8080, () => {
-        console.log(`Listening on 8080.`);
-      });
-    })
-    .catch(error => console.log({ error }));
-}, 10000);
+if (require.main === module) {
+  //Start after 10 seconds. We want InfluxDb to be ready.
+  setTimeout(function() {
+    influx
+      .getDatabaseNames()
+      .then(names => {
+        if (!names.includes("home_sensors_db")) {
+          return influx.createDatabase("home_sensors_db");
+        }
+      })
+      .then(() => {
+        app.listen(8080, () => {
+          console.log(`Listening on 8080.`);
+        });
+      })
+      .catch(error => console.log({ error }));
+  }, 10000);
+}
+
+module.exports = { validatePayload, sendNotification };

--- a/sensor-listener/package.json
+++ b/sensor-listener/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "nodemon index.js",
     "start": "node index.js"
   },
@@ -19,5 +19,8 @@
     "moment-timezone": "^0.5.27",
     "nodemon": "^2.0.2",
     "timediff": "^1.1.1"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }

--- a/weather-station/__tests__/fetchWeatherData.test.js
+++ b/weather-station/__tests__/fetchWeatherData.test.js
@@ -1,0 +1,19 @@
+const { fetchWeatherData } = require('../index');
+
+describe('fetchWeatherData', () => {
+  test('returns json when response is ok', async () => {
+    const data = { value: 1 };
+    const fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: jest.fn().mockResolvedValue(data)
+    });
+    const result = await fetchWeatherData(fetch, 'http://example.com');
+    expect(fetch).toHaveBeenCalledWith('http://example.com');
+    expect(result).toEqual(data);
+  });
+
+  test('throws error when response is not ok', async () => {
+    const fetch = jest.fn().mockResolvedValue({ ok: false, status: 500 });
+    await expect(fetchWeatherData(fetch, 'http://example.com')).rejects.toThrow('HTTP error! status: 500');
+  });
+});

--- a/weather-station/package.json
+++ b/weather-station/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "jest",
     "dev": "nodemon index.js",
     "start": "node index.js"
   },
@@ -20,5 +20,8 @@
     "moment-timezone": "^0.5.27",
     "node-fetch": "^2.6.0",
     "nodemon": "^2.0.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   }
 }


### PR DESCRIPTION
## Summary
- expose sensor listener middleware for testing
- add Jest tests covering payload validation and notification logic
- expose weather polling helper and test API fetch handling

## Testing
- `npm test` (sensor-listener) *(fails: jest not found)*
- `npm test` (weather-station) *(fails: jest not found)*


------
https://chatgpt.com/codex/tasks/task_e_6891ba8a8cc483238eb7faf930158927