### PR TITLE
Preserve fractional temperature readings in alerts

### DIFF
--- a/sensor-alerts/index.js
+++ b/sensor-alerts/index.js
@@ -40,7 +40,7 @@ connections.redisSubscriber.on("message", async (channel, message) => {
     return;
   }
 
-  const currentTemp = parseInt(current_temperature, 10);
+  const currentTemp = Number(current_temperature);
   if (!Number.isFinite(currentTemp)) {
     console.warn(
       `Invalid current_temperature received: ${current_temperature}`

--- a/sensor-alerts/test.js
+++ b/sensor-alerts/test.js
@@ -1,41 +1,85 @@
 const assert = require('assert');
 const Module = require('module');
 
-const originalRequire = Module.prototype.require;
-let sendMsgCalled = false;
-let redisSetCalled = false;
+async function testAwsNotification() {
+  const originalRequire = Module.prototype.require;
+  let sendMsgCalled = false;
+  let redisSetCalled = false;
 
-Module.prototype.require = function(request) {
-  if (request === 'aws-sns-sms') {
-    return function(config, msg) {
-      sendMsgCalled = true;
-      return Promise.resolve();
-    };
-  }
-  if (request === './email-sender') {
-    return { sendEmailAlert: () => Promise.resolve() };
-  }
-  if (request === './connections') {
-    return { asyncRedisClient: { set: async () => { redisSetCalled = true; } } };
-  }
-  return originalRequire.apply(this, arguments);
-};
+  Module.prototype.require = function(request) {
+    if (request === 'aws-sns-sms') {
+      return function(config, msg) {
+        sendMsgCalled = true;
+        return Promise.resolve();
+      };
+    }
+    if (request === './email-sender') {
+      return { sendEmailAlert: () => Promise.resolve() };
+    }
+    if (request === './connections') {
+      return { asyncRedisClient: { set: async () => { redisSetCalled = true; } } };
+    }
+    return originalRequire.apply(this, arguments);
+  };
 
-const awsNotification = require('./aws-notification');
+  const awsNotification = require('./aws-notification');
+  Module.prototype.require = originalRequire;
 
-Module.prototype.require = originalRequire;
+  process.env.ENABLE_SMS_ALERTS = 'true';
 
-process.env.ENABLE_SMS_ALERTS = 'true';
-
-async function run() {
   await awsNotification.sendNotification({
     userid: 'user1',
     location: 'Sydney',
     currentDt: Date.now(),
     message: 'Temperature alert'
   });
+
   assert(sendMsgCalled, 'sendMsg should be called');
   assert(redisSetCalled, 'redis set should be called');
+}
+
+async function testFractionalTemperatureTriggersAlert() {
+  const originalRequire = Module.prototype.require;
+  let handler;
+  let notificationCalled = false;
+
+  Module.prototype.require = function(request) {
+    if (request === './connections') {
+      return {
+        redisSubscriber: {
+          on: (event, h) => {
+            if (event === 'message') handler = h;
+          },
+          subscribe: () => {}
+        },
+        asyncRedisClient: { get: async () => null }
+      };
+    }
+    if (request === './aws-notification') {
+      return { sendNotification: () => { notificationCalled = true; } };
+    }
+    return originalRequire.apply(this, arguments);
+  };
+
+  process.env.MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION = '0';
+  process.env.TEMPERATURE_THRESHOLD_IN_CELSIUS = '25';
+  delete require.cache[require.resolve('./index.js')];
+  require('./index.js');
+  Module.prototype.require = originalRequire;
+
+  const message = JSON.stringify({
+    userid: 'user1',
+    location: 'Sydney',
+    current_temperature: 25.6
+  });
+  await handler('insert', message);
+
+  assert(notificationCalled, 'Notification should be sent for fractional temperature above threshold');
+}
+
+async function run() {
+  await testAwsNotification();
+  await testFractionalTemperatureTriggersAlert();
   console.log('All tests passed');
 }
 

--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -71,7 +71,7 @@ function writeToInflux(req, res, next) {
 }
 
 async function sendNotification(req, res) {
-  const temp = parseInt(req.body.temperature, 10);
+  const temp = Number(req.body.temperature);
   if (!Number.isFinite(temp)) {
     res.status(400).send("Invalid temperature data.");
     return;


### PR DESCRIPTION
## Summary
- prevent truncating decimal temperatures in sensor listener and alert services
- add regression test ensuring fractional readings trigger alerts

## Testing
- `npm test --prefix sensor-alerts`
- `npm test --prefix sensor-listener` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6891bff42be08323a9fe6b8a0e87fb0c