### PR TITLE
Handle missing temperature sensor devices

### DIFF
--- a/home-automation/sensor_read.py
+++ b/home-automation/sensor_read.py
@@ -18,8 +18,10 @@ os.system('modprobe w1-gpio')
 os.system('modprobe w1-therm')
 
 base_dir = '/sys/bus/w1/devices/'
-device_folder = glob.glob(base_dir + '28*')[0]
-device_file = device_folder + '/w1_slave'
+device_folders = glob.glob(base_dir + '28*')
+if not device_folders:
+    raise FileNotFoundError(f"No temperature sensor device found in {base_dir}")
+device_file = device_folders[0] + '/w1_slave'
 
 headers = {'Content-type': 'application/json',
            'x-api-key': API_KEY}


### PR DESCRIPTION
## Summary
- validate that a w1 temperature sensor device is present before reading

## Testing
- `python -m py_compile home-automation/sensor_read.py`


------
https://chatgpt.com/codex/tasks/task_e_6891bffd9d1c8323b12b7ffac8355bc4