### PR TITLE
Handle JSON parse errors in sensor alerts

### DIFF
--- a/sensor-alerts/index.js
+++ b/sensor-alerts/index.js
@@ -30,7 +30,15 @@ connections.redisSubscriber.on("message", async (channel, message) => {
     console.log("message received, " + message);
   }
 
-  const { userid, location, current_temperature } = JSON.parse(message);
+  let parsedMessage;
+  try {
+    parsedMessage = JSON.parse(message);
+  } catch (err) {
+    console.warn("Failed to parse message", err);
+    return;
+  }
+
+  const { userid, location, current_temperature } = parsedMessage;
 
   //Check required fields.
   if (!userid || !location || !current_temperature) {


### PR DESCRIPTION
## Summary
- guard Redis subscriber from crashing on bad JSON
- log warning and exit early when message parsing fails

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891c49f87b08323a94ed353740bbb3b