### PR TITLE
Handle redis notification fetch errors in sensor listener

### DIFF
--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -99,10 +99,18 @@ async function sendNotification(req, res) {
     );
   }
 
-  const notification = await asyncRedisClient.get(userId);
-  const dt = !notification
-    ? minDate
-    : new Date(JSON.parse(notification).last_notification_time);
+  let dt;
+  try {
+    const notification = await asyncRedisClient.get(userId);
+    const parsedNotification = notification ? JSON.parse(notification) : null;
+    dt = parsedNotification
+      ? new Date(parsedNotification.last_notification_time)
+      : minDate;
+  } catch (err) {
+    console.error("Failed to retrieve notification data", err);
+    res.status(500).send("Failed to retrieve notification data.");
+    return;
+  }
   const diffInMinutes = timediff(dt, Date.now(), "m");
 
   if (


### PR DESCRIPTION
## Summary
- guard redis notification fetch and JSON parsing with try/catch
- respond with HTTP 500 when redis read or parse fails

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_6891c7ccf5a0832391589a82aab30495