### PR TITLE
Handle Redis errors gracefully in alert service

### DIFF
--- a/sensor-alerts/index.js
+++ b/sensor-alerts/index.js
@@ -67,7 +67,13 @@ connections.redisSubscriber.on("message", async (channel, message) => {
   }
 
   //Get last sms sent time.
-  const notificationObj = await connections.asyncRedisClient.get(userid);
+  let notificationObj;
+  try {
+    notificationObj = await connections.asyncRedisClient.get(userid);
+  } catch (err) {
+    console.warn("Failed to get last notification time from Redis", err);
+    notificationObj = null;
+  }
 
   const dt = !notificationObj
     ? minDate
@@ -78,8 +84,7 @@ connections.redisSubscriber.on("message", async (channel, message) => {
   const notificationDetails = {
     userid,
     currentDt,
-    location,
-    message
+    location
   };
 
   //Log.


### PR DESCRIPTION
## Summary
- catch Redis access errors in sensor alert listener
- initialize notificationDetails without undefined message field

## Testing
- `cd sensor-alerts && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6891c7d2b158832399e3b9d85b963c21