### PR TITLE
chore: pin Node 18 in Dockerfiles

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -29,7 +29,7 @@ The system is composed of multiple services orchestrated with
 ## Setup
 ### Prerequisites
 - Docker and Docker Compose
-- Node.js (to run services locally without Docker)
+- Node.js 18 (to run services locally without Docker)
 - AWS account with permissions for SNS and SES
 - API key for a weather provider such as OpenWeatherMap
 

--- a/sensor-alerts/Dockerfile
+++ b/sensor-alerts/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18-bullseye
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/sensor-listener/Dockerfile
+++ b/sensor-listener/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18-bullseye
 
 # Create app directory
 WORKDIR /usr/src/app

--- a/weather-station/Dockerfile
+++ b/weather-station/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18-bullseye
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Summary
- pin Node 18 in Dockerfiles
- document Node 18 requirement for local runs

## Testing
- `npm test` (sensor-alerts)
- `docker build -t sensor-alerts:test .` *(fails: command not found)*
- `apt-get update` *(fails: repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6891c7ca28d083239d877eaec0c5958a