### PR TITLE
Add initial tests for home automation modules

### DIFF
--- a/home-automation/tests/test_hello_world.py
+++ b/home-automation/tests/test_hello_world.py
@@ -1,0 +1,32 @@
+
+import importlib.util
+import sys
+import types
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+def load_module():
+    path = Path(__file__).resolve().parent.parent / 'hello_world.py'
+    spec = importlib.util.spec_from_file_location('home_automation.hello_world', path)
+    module = importlib.util.module_from_spec(spec)
+    pkg = sys.modules.setdefault('home_automation', types.ModuleType('home_automation'))
+    spec.loader.exec_module(module)
+    sys.modules['home_automation.hello_world'] = module
+    setattr(pkg, 'hello_world', module)
+    return module
+
+hello_world = load_module()
+
+def test_main_prints_greeting_and_timestamp(capsys):
+    class FakeDateTime(datetime):
+        @classmethod
+        def now(cls):
+            return datetime(2023, 1, 1, 12, 0, 0)
+
+    with patch('home_automation.hello_world.datetime', FakeDateTime):
+        hello_world.main()
+
+    captured = capsys.readouterr()
+    assert 'hello world' in captured.out
+    assert '01/01/2023 12:00:00' in captured.out

--- a/home-automation/tests/test_sensor_read.py
+++ b/home-automation/tests/test_sensor_read.py
@@ -1,0 +1,40 @@
+
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import os
+import pytest
+
+class DummyRequests:
+    class exceptions:
+        RequestException = Exception
+    class HTTPError(Exception):
+        pass
+requests = DummyRequests()
+sys.modules['requests'] = requests
+
+def load_module():
+    env = {'API_ENDPOINT': 'http://example.com', 'API_KEY': 'k'}
+    path = Path(__file__).resolve().parent.parent / 'sensor_read.py'
+    spec = importlib.util.spec_from_file_location('sensor_read', path)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(os.environ, env, clear=True),              patch('os.system', return_value=0),              patch('glob.glob', return_value=['/sys/bus/w1/devices/28-000']):
+        spec.loader.exec_module(module)
+    return module
+
+def test_load_module_failure():
+    mod = load_module()
+    with patch.object(mod.os, 'system', return_value=1):
+        with pytest.raises(OSError):
+            mod._load_module('x')
+
+def test_missing_env():
+    path = Path(__file__).resolve().parent.parent / 'sensor_read.py'
+    spec = importlib.util.spec_from_file_location('sensor_read', path)
+    module = importlib.util.module_from_spec(spec)
+    with patch.dict(os.environ, {'API_KEY': 'k'}, clear=True),              patch('os.system', return_value=0),              patch('glob.glob', return_value=['/sys/bus/w1/devices/28-000']):
+        with pytest.raises(EnvironmentError):
+            spec.loader.exec_module(module)


### PR DESCRIPTION
## Summary
- add tests validating `hello_world` output and timestamp
- cover basic environment and module-loading behavior for `sensor_read`

## Testing
- `npm test` (sensor-alerts)
- `npm test` (sensor-listener)
- `npm test` (weather-station)
- `pytest home-automation/tests`

------
https://chatgpt.com/codex/tasks/task_e_6891e473b5dc83239aad403edc73afd7