### PR TITLE
chore: remove root package-lock

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
## Summary
- remove orphaned root-level `package-lock.json` since no matching `package.json` is maintained

## Testing
- `npm test` (fails: could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_6892d2ea8f9c8323a30ea307016a61b4