### PR TITLE
chore: configure dependabot for individual projects

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,6 +1,18 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/" # or the correct directory
+    directory: "/sensor-alerts"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/sensor-listener"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/weather-station"
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "pip"
+    directory: "/home-automation"
     schedule:
       interval: "daily"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,3 +1,0 @@
-{
-  "lockfileVersion": 1
-}


### PR DESCRIPTION
## Summary
- configure dependabot for each Node subproject and the Python home-automation project
- drop unused root `package-lock.json`

## Testing
- `npm test` in sensor-alerts
- `npm test` in sensor-listener
- `npm test` in weather-station
- `python -m pytest` in home-automation


------
https://chatgpt.com/codex/tasks/task_e_6892d2e719f883239113de0d43aa1796