### PR TITLE
Add weather station env example

### DIFF
--- a/weather-station/.env.example
+++ b/weather-station/.env.example
@@ -1,0 +1,6 @@
+INFLUX_HOST=influxdb
+INFLUX_PORT=8086
+WEATHER_API_KEY=your_api_key
+WEATHER_API_ENDPOINT=https://api.openweathermap.org/data/2.5/weather
+WEATHER_API_QUERY_POSTCODE=your_postcode
+WEATHER_API_QUERY_COUNTRY_CODE=your_country_code


### PR DESCRIPTION
## Summary
- add `.env.example` for weather-station with InfluxDB and weather API placeholders

## Testing
- `cd weather-station && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892d6d423608323a5bfd747c86e324a