### PR TITLE
docs: add testing instructions for services

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,8 +86,16 @@ Repeat for `sensor-alerts` and `weather-station` with the appropriate
 environment variables.
 
 ## Testing
-The alert service contains a basic unit test.
+The `sensor-listener`, `weather-station` and `sensor-alerts` services each
+contain a basic unit test.
+
 ```bash
+cd sensor-listener
+npm test
+
+cd weather-station
+npm test
+
 cd sensor-alerts
 npm test
 ```


### PR DESCRIPTION
## Summary
- document how to run sensor-listener tests
- document how to run weather-station tests

## Testing
- `cd sensor-listener && npm test`
- `cd weather-station && npm test`
- `cd sensor-alerts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6892d6e81fb083238ee9e5e28d14dd3c