### PR TITLE
Add service README files

### DIFF
--- a/home-automation/README.md
+++ b/home-automation/README.md
@@ -1,0 +1,30 @@
+# Home Automation
+
+## Purpose
+Reads temperature data from a 1‑Wire sensor on a Raspberry Pi and submits the reading to a remote API.
+
+## Setup
+1. Create and activate a virtual environment.
+   ```bash
+   python -m venv venv
+   source venv/bin/activate
+   ```
+2. Install dependencies:
+   ```bash
+   pip install requests pytest
+   ```
+3. Set the required environment variables (see below).
+4. Run the script:
+   ```bash
+   python sensor_read.py
+   ```
+
+## Environment Variables
+- **`API_ENDPOINT`** – URL of the service that accepts temperature readings.
+- **`API_KEY`** – secret key used for authenticating with the service.
+
+## Tests
+Run the tests with:
+```bash
+pytest
+```

--- a/sensor-alerts/README.md
+++ b/sensor-alerts/README.md
@@ -1,0 +1,31 @@
+# Sensor Alerts
+
+## Purpose
+Listens for alert messages on Redis and sends notifications via SMS or e-mail when temperature thresholds are exceeded.
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure the environment variables (see below).
+3. Start the service:
+   ```bash
+   npm start
+   ```
+
+## Environment Variables
+- `REDIS_HOST` (default `redis`) – Redis hostname.
+- `REDIS_PORT` (default `6379`) – Redis port.
+- `MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION` – minutes to wait before sending another alert for the same user.
+- `TEMPERATURE_THRESHOLD_IN_CELSIUS` – temperature that triggers an alert.
+- `ENABLE_SMS_ALERTS` (default `false`) – enable SMS notifications.
+  - `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`, `TWILIO_PHONE_NUMBER`, `SMS_PHONE_NUMBER` – required when SMS alerts are enabled.
+- `ENABLE_EMAIL_ALERTS` (default `false`) – enable e-mail notifications.
+  - `SENDGRID_API_KEY`, `EMAIL_FROM`, `EMAIL_FROM_ADDRESS`, `EMAIL_LIST` – required when e-mail alerts are enabled.
+
+## Tests
+Run the unit tests with:
+```bash
+npm test
+```

--- a/sensor-listener/README.md
+++ b/sensor-listener/README.md
@@ -1,0 +1,31 @@
+# Sensor Listener
+
+## Purpose
+Provides a Node.js HTTP API that accepts temperature readings from sensors, stores them in InfluxDB and publishes alert messages to Redis when a threshold is exceeded.
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Set the required environment variables (see below).
+3. Start the service:
+   ```bash
+   npm start
+   ```
+
+## Environment Variables
+- `INFLUX_HOST` (default `influxdb`) – InfluxDB hostname.
+- `INFLUX_PORT` (default `8086`) – InfluxDB port.
+- `REDIS_HOST` (default `redis`) – Redis hostname.
+- `REDIS_PORT` (default `6379`) – Redis port.
+- `RATE_LIMIT_WINDOW_MS` (default `60000`) – time window for rate limiting in milliseconds.
+- `RATE_LIMIT_MAX_REQUESTS` (default `60`) – maximum requests allowed per window.
+- `MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION` – minutes to wait before sending another alert for the same user.
+- `TEMPERATURE_THRESHOLD_IN_CELSIUS` – temperature that triggers an alert.
+
+## Tests
+Run the unit tests with:
+```bash
+npm test
+```

--- a/weather-station/README.md
+++ b/weather-station/README.md
@@ -1,0 +1,29 @@
+# Weather Station
+
+## Purpose
+Periodically polls a public weather API and stores the observations in InfluxDB alongside local sensor data.
+
+## Setup
+1. Install dependencies:
+   ```bash
+   npm install
+   ```
+2. Configure the environment variables (see below).
+3. Start the service:
+   ```bash
+   npm start
+   ```
+
+## Environment Variables
+- `INFLUX_HOST` (default `influxdb`) – InfluxDB hostname.
+- `INFLUX_PORT` (default `8086`) – InfluxDB port.
+- `WEATHER_API_ENDPOINT` – base URL of the weather API.
+- `WEATHER_API_KEY` – API key for the weather service.
+- `WEATHER_API_QUERY_POSTCODE` – postcode for the location to query.
+- `WEATHER_API_QUERY_COUNTRY_CODE` – country code for the location.
+
+## Tests
+Run the unit tests with:
+```bash
+npm test
+```


### PR DESCRIPTION
## Summary
- document setup and environment variables for sensor-listener, sensor-alerts, weather-station, and home-automation services
- highlight API_ENDPOINT and API_KEY requirements for home-automation

## Testing
- `cd sensor-listener && npm test`
- `cd sensor-alerts && npm test`
- `cd weather-station && npm test`
- `cd home-automation && pytest`


------
https://chatgpt.com/codex/tasks/task_e_6892d7e0b8888323b40719f7849d2690