### PR TITLE
fix weather station influxdb path

### DIFF
--- a/weather-station/weather-station.dockerfile
+++ b/weather-station/weather-station.dockerfile
@@ -14,6 +14,6 @@ RUN npm install
 
 # Bundle app source
 COPY weather-station/ ./
-COPY influxdb-ready.js ./
+COPY influxdb-ready.js /usr/src/influxdb-ready.js
 
 CMD [ "npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- fix influxdb-ready module path in weather station Dockerfile

## Testing
- `docker-compose build weather-station` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed/403)*

------
https://chatgpt.com/codex/tasks/task_e_6892e21b1f648323ab0dedd3ed73ed7f