### PR TITLE
Copy config into weather-station image

### DIFF
--- a/weather-station/weather-station.dockerfile
+++ b/weather-station/weather-station.dockerfile
@@ -15,5 +15,6 @@ RUN npm install
 # Bundle app source
 COPY weather-station/ ./
 COPY influxdb-ready.js /usr/src/influxdb-ready.js
+COPY config/ /usr/src/config/
 
 CMD [ "npm", "run", "dev"]


### PR DESCRIPTION
## Summary
- copy config directory into weather-station image so config module can be resolved

## Testing
- `npm test`
- `MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION=1 TEMPERATURE_THRESHOLD_IN_CELSIUS=1 node -e 'console.log(process.cwd()); console.log(require("../config/config").INFLUX_HOST)'` (within weather-station directory)
- `docker-compose build weather-station` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892e3cb79b08323bcc2f0dea2e34829