### PR TITLE
Copy config into weather-station image

### DIFF
--- a/weather-station/Dockerfile
+++ b/weather-station/Dockerfile
@@ -14,5 +14,6 @@ RUN npm install
 
 # Bundle app source
 COPY . .
+COPY ../config ./config
 
 CMD [ "npm", "run", "start"]


### PR DESCRIPTION
## Summary
- copy repository config folder into weather-station image so that `/usr/src/app/config` is present at runtime

## Testing
- `docker build -t weather-station-test .` *(fails: command not found)*
- `apt-get update` *(fails: repository InRelease not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6892f3b40868832387cfefb40b2171f8