### PR TITLE
feat: use WeatherAPI base endpoint

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -23,8 +23,8 @@ const env = cleanEnv(process.env, {
   // Weather-station API query parameters.
   WEATHER_API_QUERY_POSTCODE: str({ default: '2226', optional: true }),      // ZIP/postcode
   WEATHER_API_QUERY_COUNTRY_CODE: str({ default: 'AU', optional: true }), // ISO country code
-  WEATHER_API_KEY: str({ default: 'be3e885a5dabb2dff53bf29bb59246ec', optional: true }),                // weather-service API key
-  WEATHER_API_ENDPOINT: str({ default: 'https://api.openweathermap.org/data/2.5', optional: true }),           // weather-service base URL
+  WEATHER_API_KEY: str({ default: 'be3e885a5dabb2dff53bf29bb59246ec', optional: true }),                // WeatherAPI key
+  WEATHER_API_ENDPOINT: str({ default: 'https://api.weatherapi.com/v1', optional: true }),           // WeatherAPI base URL
 
   // Twilio SMS alert configuration.
   TWILIO_ACCOUNT_SID: str({ default: undefined, optional: true }), // Twilio account SID


### PR DESCRIPTION
## Summary
- default to WeatherAPI base URL instead of OpenWeatherMap
- update weather config comments to reference WeatherAPI

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/home-sensor/package.json')*


------
https://chatgpt.com/codex/tasks/task_e_6893240d000c832390ca3761476aa469