### PR TITLE
Use WeatherAPI data in weather station

### DIFF
--- a/weather-station/parseWeather.js
+++ b/weather-station/parseWeather.js
@@ -1,0 +1,29 @@
+const d2d = require("degrees-to-direction");
+
+function parseWeatherData(json) {
+  if (!json || !json.location || !json.current) {
+    throw new Error("Invalid WeatherAPI response");
+  }
+  const current = json.current;
+  return {
+    name: json.location.name,
+    currentTemp: current.temp_c,
+    feels_like: current.feelslike_c,
+    temp_min: current.temp_c,
+    temp_max: current.temp_c,
+    humidity: current.humidity,
+    wind_speed: isNaN(current.wind_kph) ? 0 : current.wind_kph,
+    wind_direction: isNaN(current.wind_degree) ? 0 : current.wind_degree,
+    wind_direction_desc: current.wind_dir || (isNaN(current.wind_degree) ? "n/a" : d2d(current.wind_degree)),
+    gust_speed: isNaN(current.gust_kph) ? 0 : current.gust_kph,
+    sunrise: 0,
+    sunset: 0,
+    weather_main: current.condition ? current.condition.text : "n/a",
+    weather_description: current.condition ? current.condition.text : "n/a",
+    sunrise_time: "n/a",
+    sunset_time: "n/a",
+    timestamp: json.location.localtime_epoch
+  };
+}
+
+module.exports = { parseWeatherData };

--- a/weather-station/test.js
+++ b/weather-station/test.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const { parseWeatherData } = require('./parseWeather');
 
 function testMissingEnvVarsThrows() {
   const Module = require('module');
@@ -29,8 +30,31 @@ function testMissingEnvVarsThrows() {
   Module.prototype.require = originalRequire;
 }
 
+function testParseWeatherData() {
+  const sample = {
+    location: { name: 'Sydney', localtime_epoch: 1609459200 },
+    current: {
+      temp_c: 25,
+      feelslike_c: 26,
+      humidity: 60,
+      wind_kph: 10,
+      wind_degree: 90,
+      wind_dir: 'E',
+      gust_kph: 15,
+      condition: { text: 'Sunny' }
+    }
+  };
+  const result = parseWeatherData(sample);
+  assert.strictEqual(result.name, 'Sydney');
+  assert.strictEqual(result.currentTemp, 25);
+  assert.strictEqual(result.wind_speed, 10);
+  assert.strictEqual(result.wind_direction_desc, 'E');
+  assert.strictEqual(result.weather_main, 'Sunny');
+}
+
 function run() {
   testMissingEnvVarsThrows();
+  testParseWeatherData();
   console.log('All tests passed');
 }
 


### PR DESCRIPTION
## Summary
- fetch weather using WeatherAPI key/q parameters
- parse WeatherAPI response shape and drop unit conversions
- add tests covering JSON parsing

## Testing
- `cd weather-station && npm test >/tmp/test.log && tail -n 20 /tmp/test.log`


------
https://chatgpt.com/codex/tasks/task_e_689325334b208323a80b2e6f8cc3bb51