### PR TITLE
Switch weather API query to latitude/longitude

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -21,8 +21,8 @@ const env = cleanEnv(process.env, {
   TEMPERATURE_THRESHOLD_IN_CELSIUS: num({ default: 30, optional: true }),             // temperature triggering an alert
 
   // Weather-station API query parameters.
-  WEATHER_API_QUERY_POSTCODE: str({ default: '<post_code>', optional: true }),      // ZIP/postcode
-  WEATHER_API_QUERY_COUNTRY_CODE: str({ default: '<country_code>', optional: true }), // ISO country code
+  WEATHER_API_LATITUDE: num({ default: undefined, optional: true }),      // latitude
+  WEATHER_API_LONGITUDE: num({ default: undefined, optional: true }),     // longitude
   WEATHER_API_KEY: str({ default: '<secret>', optional: true }),                // WeatherAPI key
   WEATHER_API_ENDPOINT: str({ default: 'https://api.weatherapi.com/v1', optional: true }),           // WeatherAPI base URL
 

--- a/readme.md
+++ b/readme.md
@@ -65,8 +65,8 @@ to `.env` and adjust the values as needed, or provide the variables at runtime.
 - `INFLUX_PORT` – port for InfluxDB (default: `8086`).
 - `WEATHER_API_KEY`
 - `WEATHER_API_ENDPOINT` – e.g. `https://api.weatherapi.com/v1/current.json`
-- `WEATHER_API_QUERY_POSTCODE`
-- `WEATHER_API_QUERY_COUNTRY_CODE`
+- `WEATHER_API_LATITUDE`
+- `WEATHER_API_LONGITUDE`
 
 ### Running
 #### Using Docker Compose

--- a/weather-station/README.md
+++ b/weather-station/README.md
@@ -19,8 +19,8 @@ Periodically polls a public weather API and stores the observations in InfluxDB 
 - **INFLUX_PORT** (default `8086`) – InfluxDB port.
 - **WEATHER_API_ENDPOINT** – base URL of the weather API.
 - **WEATHER_API_KEY** – API key for the weather service.
-- **WEATHER_API_QUERY_POSTCODE** – postcode for the location to query.
-- **WEATHER_API_QUERY_COUNTRY_CODE** – country code for the location.
+- **WEATHER_API_LATITUDE** – latitude for the location to query.
+- **WEATHER_API_LONGITUDE** – longitude for the location.
 
 ## Tests
 Run the unit tests with:

--- a/weather-station/index.js
+++ b/weather-station/index.js
@@ -6,15 +6,15 @@ const waitForInfluxDb = require("../influxdb-ready").waitForInfluxDb;
 const config = require("../config/config");
 const { parseWeatherData } = require("./parseWeather");
 
-const zipCode = config.WEATHER_API_QUERY_POSTCODE;
-const countryCode = config.WEATHER_API_QUERY_COUNTRY_CODE;
+const latitude = config.WEATHER_API_LATITUDE;
+const longitude = config.WEATHER_API_LONGITUDE;
 const appid = config.WEATHER_API_KEY;
 const apiEndpoint = config.WEATHER_API_ENDPOINT;
 
-if (!zipCode || !countryCode || !appid || !apiEndpoint) {
+if (latitude == null || longitude == null || !appid || !apiEndpoint) {
   const missingVars = [
-    !zipCode && "WEATHER_API_QUERY_POSTCODE",
-    !countryCode && "WEATHER_API_QUERY_COUNTRY_CODE",
+    latitude == null && "WEATHER_API_LATITUDE",
+    longitude == null && "WEATHER_API_LONGITUDE",
     !appid && "WEATHER_API_KEY",
     !apiEndpoint && "WEATHER_API_ENDPOINT"
   ]
@@ -27,16 +27,16 @@ const baseUrl = apiEndpoint.endsWith("/")
   ? apiEndpoint.slice(0, -1)
   : apiEndpoint;
 const url = `${baseUrl}/current.json?key=${encodeURIComponent(appid)}&q=${encodeURIComponent(
-  zipCode
-)},${encodeURIComponent(countryCode)}`;
+  latitude
+)},${encodeURIComponent(longitude)}`;
 
 if (process.env.NODE_ENV !== "production") {
   const redactedUrl = new URL(url);
   redactedUrl.searchParams.set("key", "***");
   console.log({
     apiEndpoint: apiEndpoint,
-    postCode: zipCode,
-    countryCode: countryCode,
+    latitude,
+    longitude,
     invokeUrl: redactedUrl.toString()
   });
 }

--- a/weather-station/test.js
+++ b/weather-station/test.js
@@ -7,8 +7,8 @@ function testMissingEnvVarsThrows() {
   Module.prototype.require = function(request) {
     if (request === '../config/config') {
       return {
-        WEATHER_API_QUERY_POSTCODE: undefined,
-        WEATHER_API_QUERY_COUNTRY_CODE: undefined,
+        WEATHER_API_LATITUDE: undefined,
+        WEATHER_API_LONGITUDE: undefined,
         WEATHER_API_KEY: undefined,
         WEATHER_API_ENDPOINT: undefined,
         INFLUX_HOST: 'influxdb',


### PR DESCRIPTION
## Summary
- replace postcode and country code configuration with `WEATHER_API_LATITUDE` and `WEATHER_API_LONGITUDE`
- query the weather API by coordinates and update tests accordingly
- document new environment variables across weather-station and root readme

## Testing
- `npm test` (weather-station)
- `npm test` (sensor-listener)
- `npm test` (sensor-alerts)


------
https://chatgpt.com/codex/tasks/task_e_68934be17c5c83238da8b7a972032f48