### PR TITLE
Add deploy workflow using GitHub Secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,20 @@
+name: Deploy
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      WEATHER_API_KEY: ${{ secrets.WEATHER_API_KEY }}
+      TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
+      TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+      TWILIO_PHONE_NUMBER: ${{ secrets.TWILIO_PHONE_NUMBER }}
+      SENDGRID_API_KEY: ${{ secrets.SENDGRID_API_KEY }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Run Docker Compose
+        run: docker compose up --build -d

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,8 @@ services:
     volumes:
       - /usr/src/app/node_modules #bookmark volume (i.e. do NOT map to volume)
       - ./weather-station:/usr/src/app
+    environment:
+      - WEATHER_API_KEY
   sensor-alerts:
     restart: always
     build:
@@ -26,6 +28,11 @@ services:
     volumes:
       - /usr/src/app/node_modules #bookmark volume (i.e. do NOT map to volume)
       - ./sensor-alerts:/usr/src/app
+    environment:
+      - TWILIO_ACCOUNT_SID
+      - TWILIO_AUTH_TOKEN
+      - TWILIO_PHONE_NUMBER
+      - SENDGRID_API_KEY
   influxdb:
     image: influxdb:1.8  # or influxdb:2.7 if you're using v2
     volumes:

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,13 @@ npm start
 Repeat for `sensor-alerts` and `weather-station` with the appropriate
 environment variables.
 
+### GitHub Actions deployment
+Secrets such as `WEATHER_API_KEY`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`,
+`TWILIO_PHONE_NUMBER`, and `SENDGRID_API_KEY` are stored in the repository's
+**Settings → Secrets and variables → Actions**. The deployment workflow reads
+these values and exposes them to `docker compose up` so they are available to
+the running services.
+
 ## Testing
 The `sensor-listener`, `weather-station` and `sensor-alerts` services each
 contain a basic unit test.


### PR DESCRIPTION
## Summary
- run deployment with docker compose in new GitHub Actions workflow
- reference WEATHER_API_KEY and Twilio/SendGrid secrets in services
- document that secrets come from repository Actions secrets

## Testing
- `npm test` (sensor-listener)
- `npm test` (sensor-alerts)
- `npm test` (weather-station)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893513eb1048323a8ccccbe74736d79