### PR TITLE
Expose weather coordinates

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       WEATHER_API_KEY: ${{ secrets.WEATHER_API_KEY }}
+      WEATHER_API_LATITUDE: ${{ secrets.WEATHER_API_LATITUDE }}
+      WEATHER_API_LONGITUDE: ${{ secrets.WEATHER_API_LONGITUDE }}
       TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
       TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
       TWILIO_PHONE_NUMBER: ${{ secrets.TWILIO_PHONE_NUMBER }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,8 @@ services:
       - ./weather-station:/usr/src/app
     environment:
       - WEATHER_API_KEY
+      - WEATHER_API_LATITUDE
+      - WEATHER_API_LONGITUDE
   sensor-alerts:
     restart: always
     build:

--- a/readme.md
+++ b/readme.md
@@ -87,7 +87,7 @@ Repeat for `sensor-alerts` and `weather-station` with the appropriate
 environment variables.
 
 ### GitHub Actions deployment
-Secrets such as `WEATHER_API_KEY`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`,
+Secrets such as `WEATHER_API_KEY`, `WEATHER_API_LATITUDE`, `WEATHER_API_LONGITUDE`, `TWILIO_ACCOUNT_SID`, `TWILIO_AUTH_TOKEN`,
 `TWILIO_PHONE_NUMBER`, and `SENDGRID_API_KEY` are stored in the repository's
 **Settings → Secrets and variables → Actions**. The deployment workflow reads
 these values and exposes them to `docker compose up` so they are available to


### PR DESCRIPTION
## Summary
- expose weather coordinates for deployment and docker compose
- document required weather coordinate secrets

## Testing
- `npm test` (sensor-listener)
- `npm test` (weather-station)
- `npm test` (sensor-alerts)


------
https://chatgpt.com/codex/tasks/task_e_68935734dc648323ac56e9d4ece5c979