### PR TITLE
Use lat/lon for weather API configuration

### DIFF
--- a/weather-station/.env.example
+++ b/weather-station/.env.example
@@ -1,6 +1,6 @@
 INFLUX_HOST=influxdb
 INFLUX_PORT=8086
 WEATHER_API_KEY=your_api_key
-WEATHER_API_ENDPOINT=https://api.openweathermap.org/data/2.5/weather
-WEATHER_API_QUERY_POSTCODE=your_postcode
-WEATHER_API_QUERY_COUNTRY_CODE=your_country_code
+WEATHER_API_ENDPOINT=https://api.weatherapi.com/v1
+WEATHER_API_LATITUDE=51.5074
+WEATHER_API_LONGITUDE=-0.1278


### PR DESCRIPTION
## Summary
- replace postcode and country code query vars with latitude and longitude
- point Weather API endpoint to https://api.weatherapi.com/v1

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68935736690083238dc49e341346ce5c