### PR TITLE
Make weather API configuration mandatory

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -21,9 +21,9 @@ const env = cleanEnv(process.env, {
   TEMPERATURE_THRESHOLD_IN_CELSIUS: num({ default: 30, optional: true }),             // temperature triggering an alert
 
   // Weather-station API query parameters.
-  WEATHER_API_LATITUDE: num({ default: undefined, optional: true }),      // latitude
-  WEATHER_API_LONGITUDE: num({ default: undefined, optional: true }),     // longitude
-  WEATHER_API_KEY: str({ default: '<secret>', optional: true }),                // WeatherAPI key
+  WEATHER_API_LATITUDE: num(),      // latitude
+  WEATHER_API_LONGITUDE: num(),     // longitude
+  WEATHER_API_KEY: str(),                // WeatherAPI key
   WEATHER_API_ENDPOINT: str({ default: 'https://api.weatherapi.com/v1', optional: true }),           // WeatherAPI base URL
 
   // Twilio SMS alert configuration.

--- a/weather-station/index.js
+++ b/weather-station/index.js
@@ -3,25 +3,19 @@ const AsyncPolling = require("async-polling");
 const fetch = require("node-fetch");
 const moment = require("moment-timezone");
 const waitForInfluxDb = require("../influxdb-ready").waitForInfluxDb;
-const config = require("../config/config");
+let config;
+try {
+  config = require("../config/config");
+} catch (error) {
+  console.error("Missing or invalid environment variables:", error.message);
+  process.exit(1);
+}
 const { parseWeatherData } = require("./parseWeather");
 
 const latitude = config.WEATHER_API_LATITUDE;
 const longitude = config.WEATHER_API_LONGITUDE;
 const appid = config.WEATHER_API_KEY;
 const apiEndpoint = config.WEATHER_API_ENDPOINT;
-
-if (latitude == null || longitude == null || !appid || !apiEndpoint) {
-  const missingVars = [
-    latitude == null && "WEATHER_API_LATITUDE",
-    longitude == null && "WEATHER_API_LONGITUDE",
-    !appid && "WEATHER_API_KEY",
-    !apiEndpoint && "WEATHER_API_ENDPOINT"
-  ]
-    .filter(Boolean)
-    .join(", ");
-  throw new Error(`Missing required environment variables: ${missingVars}`);
-}
 
 const baseUrl = apiEndpoint.endsWith("/")
   ? apiEndpoint.slice(0, -1)


### PR DESCRIPTION
## Summary
- enforce weather API credentials and coordinates in config
- guard weather station startup with helpful error message when env vars missing
- verify weather station exits cleanly when required env vars absent

## Testing
- `npm test` in weather-station
- `npm test` in sensor-listener

------
https://chatgpt.com/codex/tasks/task_e_6893dee01f888323a2f77207b99a4039