### PR TITLE
Simplify Grafana Dockerfile with provisioning

### DIFF
--- a/grafana/dashboards/home.json
+++ b/grafana/dashboards/home.json
@@ -1,0 +1,9 @@
+{
+  "id": null,
+  "uid": "home",
+  "title": "Home",
+  "timezone": "browser",
+  "schemaVersion": 38,
+  "version": 0,
+  "panels": []
+}

--- a/grafana/grafana.dockerfile
+++ b/grafana/grafana.dockerfile
@@ -1,9 +1,6 @@
 FROM grafana/grafana
 USER root
-
-RUN apk update
-RUN apk add
-RUN apk add --update curl
-
-#expose port
+RUN apk update && apk add --no-cache curl
+COPY provisioning/ /etc/grafana/provisioning/
+COPY dashboards/ /var/lib/grafana/dashboards/
 EXPOSE 3000

--- a/grafana/provisioning/dashboards/dashboard.yml
+++ b/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    allowUiUpdates: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/datasource.yml
+++ b/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    isDefault: true


### PR DESCRIPTION
## Summary
- Streamlined Grafana Dockerfile and install curl
- Add provisioning configuration and sample dashboard

## Testing
- `docker compose build grafana` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893f0cebad88323bc768c1bcac23c7f