### PR TITLE
Add Grafana provisioning for weather dashboard

### DIFF
--- a/grafana/dashboards/weather.json
+++ b/grafana/dashboards/weather.json
@@ -1,0 +1,107 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {},
+        "overrides": []
+      },
+      "id": 1,
+      "targets": [
+        {
+          "groupBy": [
+            { "type": "time", "params": ["$__interval"] },
+            { "type": "fill", "params": ["null"] }
+          ],
+          "measurement": "temperature_data_in_celsius",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              { "type": "field", "params": ["temperature"] },
+              { "type": "mean", "params": [] }
+            ]
+          ]
+        }
+      ],
+      "title": "Temperature",
+      "type": "timeseries"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m/s"
+        },
+        "overrides": []
+      },
+      "id": 2,
+      "targets": [
+        {
+          "measurement": "daily_read",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              { "type": "field", "params": ["wind_speed"] },
+              { "type": "last", "params": [] }
+            ]
+          ]
+        }
+      ],
+      "title": "Wind Speed",
+      "type": "gauge"
+    },
+    {
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "min": 0,
+          "max": 360,
+          "unit": "degree"
+        },
+        "overrides": []
+      },
+      "id": 3,
+      "targets": [
+        {
+          "measurement": "daily_read",
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              { "type": "field", "params": ["wind_direction"] },
+              { "type": "last", "params": [] }
+            ]
+          ]
+        }
+      ],
+      "title": "Wind Direction",
+      "type": "gauge"
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 27,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Weather",
+  "uid": "weather-dashboard",
+  "version": 1
+}

--- a/grafana/grafana.dockerfile
+++ b/grafana/grafana.dockerfile
@@ -2,8 +2,10 @@ FROM grafana/grafana
 USER root
 
 RUN apk update
-RUN apk add
 RUN apk add --update curl
+
+COPY provisioning/ /etc/grafana/provisioning/
+COPY dashboards/ /var/lib/grafana/dashboards/
 
 #expose port
 EXPOSE 3000

--- a/grafana/provisioning/dashboards/weather.yml
+++ b/grafana/provisioning/dashboards/weather.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+providers:
+  - name: Weather
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/grafana/provisioning/datasources/influx.yml
+++ b/grafana/provisioning/datasources/influx.yml
@@ -1,0 +1,9 @@
+apiVersion: 1
+datasources:
+  - name: InfluxDB
+    type: influxdb
+    access: proxy
+    url: http://influxdb:8086
+    database: home_sensors_db
+    isDefault: true
+    editable: true


### PR DESCRIPTION
## Summary
- add InfluxDB datasource provisioning
- auto-load weather dashboard JSON
- update Grafana Dockerfile to copy provisioning and dashboards

## Testing
- `npm test` *(fails: Could not read package.json)*
- `docker build -f grafana/grafana.dockerfile grafana` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893f0c31eac8323846680ff16000592