### PR TITLE
Add Grafana provisioning and weather dashboard

### DIFF
--- a/grafana/dashboards/weather.json
+++ b/grafana/dashboards/weather.json
@@ -1,0 +1,59 @@
+{
+  "id": null,
+  "title": "Weather Dashboard",
+  "timezone": "browser",
+  "schemaVersion": 16,
+  "version": 0,
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Temperature",
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "celsius"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "query": "SELECT mean(\"temperature\") FROM \"weather\" WHERE $timeFilter GROUP BY time($__interval) fill(null)"
+        }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Wind Speed",
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "m/s"
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "query": "SELECT last(\"wind_speed\") FROM \"weather\" WHERE $timeFilter"
+        }
+      ]
+    },
+    {
+      "type": "gauge",
+      "title": "Wind Direction",
+      "datasource": "InfluxDB",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "degree",
+          "min": 0,
+          "max": 360
+        },
+        "overrides": []
+      },
+      "targets": [
+        {
+          "query": "SELECT last(\"wind_direction\") FROM \"weather\" WHERE $timeFilter"
+        }
+      ]
+    }
+  ]
+}

--- a/grafana/provisioning/dashboards/weather.yml
+++ b/grafana/provisioning/dashboards/weather.yml
@@ -1,7 +1,7 @@
 apiVersion: 1
 
 providers:
-  - name: 'default'
+  - name: 'weather'
     orgId: 1
     folder: ''
     type: file

--- a/grafana/provisioning/datasources/influx.yml
+++ b/grafana/provisioning/datasources/influx.yml
@@ -5,4 +5,5 @@ datasources:
     type: influxdb
     access: proxy
     url: http://influxdb:8086
+    database: home_sensors_db
     isDefault: true


### PR DESCRIPTION
## Summary
- configure InfluxDB datasource for home sensors in Grafana provisioning
- load dashboards from `/var/lib/grafana/dashboards`
- add weather dashboard showing temperature, wind speed, and wind direction

## Testing
- `npm test` *(fails: ENOENT package.json)*


------
https://chatgpt.com/codex/tasks/task_e_6893f353e9088323a5a828a7334a9f10