### PR TITLE
Use apt-get for curl in Grafana Dockerfile

### DIFF
--- a/grafana/grafana.dockerfile
+++ b/grafana/grafana.dockerfile
@@ -1,6 +1,6 @@
 FROM grafana/grafana
 USER root
-RUN apk update && apk add --no-cache curl
+RUN apt-get update && apt-get install -y curl
 COPY provisioning/ /etc/grafana/provisioning/
 COPY dashboards/ /var/lib/grafana/dashboards/
 EXPOSE 3000


### PR DESCRIPTION
## Summary
- switch Grafana Dockerfile to use `apt-get` for installing `curl`

## Testing
- `docker build -f grafana/grafana.dockerfile -t grafana-test grafana` *(fails: command not found: docker)*
- `apt-get update` *(fails: repository InRelease files not signed)*

------
https://chatgpt.com/codex/tasks/task_e_6893f3520ef88323aa3e08604091bb62