### PR TITLE
Simplify temperature handling with payload sanitization

### DIFF
--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -54,6 +54,7 @@ function validatePayload(req, res, next) {
     res.status(400).send("Invalid payload");
     return;
   }
+  req.body = result.data;
   next();
 }
 
@@ -80,11 +81,7 @@ async function sendNotification(req, res, next) {
     res.status(400).send("Missing or invalid user id.");
     return;
   }
-  const temp = Number(req.body.temperature);
-  if (!Number.isFinite(temp)) {
-    res.status(400).send("Invalid temperature data.");
-    return;
-  }
+  const temp = req.body.temperature;
 
   if (temp < TEMPERATURE_THRESHOLD_IN_CELSIUS) {
     res.send("posted temperature data.");

--- a/sensor-listener/test.js
+++ b/sensor-listener/test.js
@@ -105,10 +105,11 @@ function testInvalidLocation() {
 
 function testValidPayload() {
   const { res, next, wasNextCalled } = createMock();
-  const req = { body: { temperature: 25.5, location: 'Sydney' } };
+  const req = { body: { temperature: 25.5, location: 'Sydney', extra: 'ignore' } };
   validatePayload(req, res, next);
   assert.strictEqual(res.statusCode, null);
   assert.strictEqual(wasNextCalled(), true);
+  assert.deepStrictEqual(req.body, { temperature: 25.5, location: 'Sydney' });
 }
 
 async function testHealthEndpoint() {


### PR DESCRIPTION
## Summary
- sanitize request body and rely on schema validation in `validatePayload`
- streamline `sendNotification` by trusting sanitized temperature
- add test to ensure extra fields are stripped during payload validation

## Testing
- `cd sensor-listener && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6893f6472c008323bcb4158b84fd4371