### PR TITLE
Handle Redis subscription failures

### DIFF
--- a/sensor-alerts/index.js
+++ b/sensor-alerts/index.js
@@ -19,10 +19,11 @@ if (
 }
 
 (async () => {
-  await connections.redisSubscriber.subscribe("insert", async message => {
-    if (process.env.NODE_ENV !== "production") {
-      console.log("message received, " + message);
-    }
+  try {
+    await connections.redisSubscriber.subscribe("insert", async message => {
+      if (process.env.NODE_ENV !== "production") {
+        console.log("message received, " + message);
+      }
 
   let parsedMessage;
   try {
@@ -109,8 +110,12 @@ if (
     } catch (err) {
       console.error("Failed to send notification", err);
     }
-  } else {
-    console.log("time threshold has not exceeded. Ignore!");
-  }
+    } else {
+      console.log("time threshold has not exceeded. Ignore!");
+    }
   });
+  } catch (err) {
+    console.error("Failed to subscribe to Redis channel 'insert'", err);
+    process.exit(1);
+  }
 })();


### PR DESCRIPTION
## Summary
- handle Redis subscription errors by wrapping subscribe in try/catch
- log a descriptive message and exit when subscription fails

## Testing
- `cd sensor-alerts && npm test`

------
https://chatgpt.com/codex/tasks/task_e_68954e0318f48323b25575f5a75c34fc