### PR TITLE
Improve Redis connection resilience

### DIFF
--- a/sensor-alerts/connections.js
+++ b/sensor-alerts/connections.js
@@ -1,15 +1,61 @@
 const { createClient } = require("redis");
 const config = require("../config/config");
 
+async function connectWithRetry(
+  client,
+  retries = config.REDIS_CONNECT_RETRIES || 5,
+  delay = config.REDIS_CONNECT_RETRY_DELAY || 1000
+) {
+  for (let attempt = 1; attempt <= retries; attempt++) {
+    try {
+      await client.connect();
+      return;
+    } catch (err) {
+      if (attempt === retries) throw err;
+      console.error(
+        `Redis connection attempt ${attempt} failed. Retrying in ${delay}ms...`,
+        err
+      );
+      await new Promise(res => setTimeout(res, delay));
+      delay *= 2;
+    }
+  }
+}
+
+function setupListeners(client, name) {
+  if (typeof client.on !== "function") return;
+
+  client.on("error", err => {
+    console.error(`Redis ${name} error`, err);
+    if (!client.isOpen) {
+      connectWithRetry(client).catch(e =>
+        console.error(`Redis ${name} reconnection error`, e)
+      );
+    }
+  });
+
+  client.on("end", () => {
+    console.error(
+      `Redis ${name} connection closed. Attempting to reconnect...`
+    );
+    connectWithRetry(client).catch(e =>
+      console.error(`Redis ${name} reconnection error`, e)
+    );
+  });
+}
+
 const redisClient = createClient({
   url: `redis://${config.REDIS_HOST}:${config.REDIS_PORT}`
 });
 const redisSubscriber = redisClient.duplicate();
 
+setupListeners(redisClient, "client");
+setupListeners(redisSubscriber, "subscriber");
+
 (async () => {
   try {
-    await redisClient.connect();
-    await redisSubscriber.connect();
+    await connectWithRetry(redisClient);
+    await connectWithRetry(redisSubscriber);
   } catch (err) {
     console.error("Redis connection error", err);
     // Exit to avoid running without a required Redis connection.

--- a/sensor-alerts/test.js
+++ b/sensor-alerts/test.js
@@ -5,7 +5,12 @@ async function testAbortWhenRedisUnreachable() {
   const originalRequire = Module.prototype.require;
   Module.prototype.require = function(request) {
     if (request === '../config/config') {
-      return { REDIS_HOST: 'redis', REDIS_PORT: 6379 };
+      return {
+        REDIS_HOST: 'redis',
+        REDIS_PORT: 6379,
+        REDIS_CONNECT_RETRIES: 1,
+        REDIS_CONNECT_RETRY_DELAY: 1
+      };
     }
     if (request === 'redis') {
       return {


### PR DESCRIPTION
## Summary
- add `connectWithRetry` to reconnect Redis connections with exponential backoff
- log `error` and `end` events on Redis clients and attempt reconnection
- expose retry and delay configuration via `REDIS_CONNECT_RETRIES` and `REDIS_CONNECT_RETRY_DELAY`

## Testing
- `cd sensor-alerts && npm test`

------
https://chatgpt.com/codex/tasks/task_e_689551b18374832393e90dda70db431f