### PR TITLE
Clarify REDIS_HOST usage outside Docker

### DIFF
--- a/sensor-alerts/.env.example
+++ b/sensor-alerts/.env.example
@@ -1,4 +1,5 @@
-REDIS_HOST=redis
+# Use 'redis' only when running inside a Docker network
+REDIS_HOST=localhost
 REDIS_PORT=6379
 MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION=0
 TEMPERATURE_THRESHOLD_IN_CELSIUS=25

--- a/sensor-alerts/README.md
+++ b/sensor-alerts/README.md
@@ -8,14 +8,14 @@ Listens for alert messages on Redis and sends notifications via SMS or e-mail wh
    ```bash
    npm install
    ```
-2. Configure the environment variables (see below).
+2. Configure the environment variables (see below). When running outside Docker, set `REDIS_HOST` to `localhost`; use `redis` only when running inside a Docker network.
 3. Start the service:
    ```bash
    npm start
    ```
 
 ## Environment Variables
-- **REDIS_HOST** (default `redis`) – Redis hostname.
+- **REDIS_HOST** (default `localhost`) – Redis hostname. Use `redis` when running inside a Docker network.
 - **REDIS_PORT** (default `6379`) – Redis port.
 - **MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION** – minutes to wait before sending another alert for the same user.
 - **TEMPERATURE_THRESHOLD_IN_CELSIUS** – temperature that triggers an alert.


### PR DESCRIPTION
## Summary
- Default `REDIS_HOST` to `localhost` in example env file with note about Docker networks
- Remind users in README to set `REDIS_HOST` when running outside Docker and update variable description

## Testing
- `cd sensor-alerts && npm test`


------
https://chatgpt.com/codex/tasks/task_e_689551a3deb8832392af8762a9832456