### PR TITLE
chore: add redis client dependency

### DIFF
--- a/sensor-listener/package-lock.json
+++ b/sensor-listener/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@redis/client": "^1.5.8",
         "actions-on-google": "^3.0.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",
@@ -140,6 +141,12 @@
         "@types/node": "*",
         "@types/send": "*"
       }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.5.8",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.5.8.tgz",
+      "integrity": "sha512-z4PhNX7vuL3xVChQ1m2AB9Yg5AULVxXcg/SpIdNs6c5H0NE8XYXysP+DGNKHfuwvY7kxvUdBeoGlODJ6+SfaPg==",
+      "license": "MIT"
     },
     "node_modules/abort-controller": {
       "version": "3.0.0",

--- a/sensor-listener/package.json
+++ b/sensor-listener/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@redis/client": "^1.5.8",
     "actions-on-google": "^3.0.0",
     "redis": "^4.6.7",
     "dotenv": "^8.2.0",


### PR DESCRIPTION
## Summary
- add `@redis/client` to sensor listener dependencies
- update lockfile for new redis client package

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_689564a209488323af648e36e914c235