### PR TITLE
Add Redis client dependency to sensor alerts service

### DIFF
--- a/sensor-alerts/package-lock.json
+++ b/sensor-alerts/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
+        "@redis/client": "^1.6.1",
         "@sendgrid/mail": "^8.1.5",
         "dotenv": "^8.2.0",
         "moment-timezone": "^0.5.27",

--- a/sensor-alerts/package.json
+++ b/sensor-alerts/package.json
@@ -16,7 +16,8 @@
     "moment-timezone": "^0.5.27",
     "timediff": "^1.1.1",
     "twilio": "^4.11.1",
-    "@sendgrid/mail": "^8.1.5"
+    "@sendgrid/mail": "^8.1.5",
+    "@redis/client": "^1.6.1"
   },
   "devDependencies": {
     "nodemon": "^2.0.2"


### PR DESCRIPTION
## Summary
- include `@redis/client` in sensor-alerts dependencies to satisfy redis v4

## Testing
- `npm test`
- `WEATHER_API_LATITUDE=0 WEATHER_API_LONGITUDE=0 WEATHER_API_KEY=none REDIS_CONNECT_RETRIES=1 node index.js`

------
https://chatgpt.com/codex/tasks/task_e_689567943384832386760785a886e184