### PR TITLE
chore: use Node 18 base image

### DIFF
--- a/sensor-listener/sensor-listener.dockerfile
+++ b/sensor-listener/sensor-listener.dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18-bullseye
 
 # Create app directory
 WORKDIR /usr/src/app


### PR DESCRIPTION
## Summary
- use Node 18 base image for sensor listener Dockerfile

## Testing
- `npm test` *(fails: Cannot find module 'express')*
- `npm install` *(fails: 403 Forbidden for @redis/client)*

------
https://chatgpt.com/codex/tasks/task_e_6895690b76c88323aa676f35cb977071