### PR TITLE
Include shared config in service Docker builds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,8 +3,8 @@ services:
   sensor-listener:
     restart: always
     build:
-      dockerfile: sensor-listener.dockerfile
-      context: ./sensor-listener
+      context: .
+      dockerfile: sensor-listener/sensor-listener.dockerfile
     volumes:
       - ./sensor-listener/node_modules:/usr/src/app/node_modules
       - ./sensor-listener:/usr/src/app
@@ -27,8 +27,8 @@ services:
   sensor-alerts:
     restart: always
     build:
-      dockerfile: sensor-alerts.dockerfile
-      context: ./sensor-alerts
+      context: .
+      dockerfile: sensor-alerts/sensor-alerts.dockerfile
     volumes:
       - /usr/src/app/node_modules #bookmark volume (i.e. do NOT map to volume)
       - ./sensor-alerts:/usr/src/app

--- a/sensor-alerts/sensor-alerts.dockerfile
+++ b/sensor-alerts/sensor-alerts.dockerfile
@@ -6,13 +6,16 @@ WORKDIR /usr/src/app
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
-COPY package*.json ./
+COPY sensor-alerts/package*.json ./
 
 RUN npm install
 # If you are building your code for production
 # RUN npm ci --only=production
 
+# Include shared configuration
+COPY config ./config
+
 # Bundle app source
-COPY . .
+COPY sensor-alerts ./
 
 CMD [ "npm", "run", "dev"]

--- a/sensor-listener/sensor-listener.dockerfile
+++ b/sensor-listener/sensor-listener.dockerfile
@@ -6,14 +6,17 @@ WORKDIR /usr/src/app
 # Install app dependencies
 # A wildcard is used to ensure both package.json AND package-lock.json are copied
 # where available (npm@5+)
-COPY package*.json ./
+COPY sensor-listener/package*.json ./
 
 RUN npm install
 # If you are building your code for production
 # RUN npm ci --only=production
 
+# Include shared configuration
+COPY config ./config
+
 # Bundle app source
-COPY . .
+COPY sensor-listener ./
 
 EXPOSE 8080
 


### PR DESCRIPTION
## Summary
- build sensor-listener and sensor-alerts images from repo root
- copy shared config directory into both service images

## Testing
- `docker-compose build sensor-alerts sensor-listener` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68956ca1bb608323a46eb267e0382482