### PR TITLE
feat(sensor-listener): add redis client dependency

### DIFF
--- a/sensor-listener/package-lock.json
+++ b/sensor-listener/package-lock.json
@@ -16,7 +16,8 @@
         "moment-timezone": "^0.5.27",
         "redis": "^4.6.7",
         "timediff": "^1.1.1",
-        "zod": "^3.22.4"
+        "zod": "^3.22.4",
+        "@redis/client": "^1.6.1"
       },
       "devDependencies": {
         "nodemon": "^2.0.2"
@@ -1324,6 +1325,44 @@
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
+    },
+    "node_modules/@redis/client": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/@redis/client/-/client-1.6.1.tgz",
+      "integrity": "sha512-/KCsg3xSlR+nCK8/8ZYSknYxvXHwubJrU82F3Lm1Fp6789VQ0/3RJKfsmRXjqfaTA++23CvC3hqmqe/2GEt6Kw==",
+      "license": "MIT",
+      "dependencies": {
+        "cluster-key-slot": "1.1.2",
+        "generic-pool": "3.9.0",
+        "yallist": "4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/cluster-key-slot": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz",
+      "integrity": "sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/generic-pool": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-3.9.0.tgz",
+      "integrity": "sha512-hymDOu5B53XvN4QT9dBmZxPX4CWhBPPLguTZ9MMFeFa/Kg0xWVfylOVNlJji/E7yTZWFd/q9GO5TxDLq156D7g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "license": "ISC"
     }
   }
 }

--- a/sensor-listener/package.json
+++ b/sensor-listener/package.json
@@ -11,6 +11,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@redis/client": "^1.6.1",
     "redis": "^4.6.7",
     "dotenv": "^8.2.0",
     "express": "^4.17.1",


### PR DESCRIPTION
## Summary
- add `@redis/client` to sensor-listener dependencies
- update lockfile to include redis client and sub-dependencies

## Testing
- `npm test`
- `node -e "require('@redis/client'); console.log('loaded @redis/client')"`


------
https://chatgpt.com/codex/tasks/task_e_6897ecf3b6248323a24e2e3402f6312f