### PR TITLE
fix: keep sensor-listener dependencies inside container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       context: .
       dockerfile: sensor-listener/sensor-listener.dockerfile
     volumes:
-      - ./sensor-listener/node_modules:/usr/src/app/node_modules
+      - /usr/src/app/node_modules
       - ./sensor-listener:/usr/src/app
     depends_on:
       - influxdb


### PR DESCRIPTION
## Summary
- use container-only node_modules volume for sensor-listener service

## Testing
- `npm test` (sensor-listener)
- `docker compose build sensor-listener` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689575cc5e7c8323861ca8486e51cfcc