### PR TITLE
refactor config import path for sensor listener

### DIFF
--- a/sensor-listener/common.js
+++ b/sensor-listener/common.js
@@ -1,7 +1,7 @@
 const Influx = require("influx");
 const { createClient } = require("redis");
 
-const config = require("../config/config");
+const config = require("./config/config");
 const influx = new Influx.InfluxDB({
   host: config.INFLUX_HOST,
   port: config.INFLUX_PORT,

--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -5,7 +5,7 @@ const timediff = require("timediff");
 const { z } = require("zod");
 const { influx, redisClient, redisPublisher } = require("./common");
 const waitForInfluxDb = require("../influxdb-ready").waitForInfluxDb;
-const config = require("../config/config");
+const config = require("./config/config");
 
 const {
   MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION,

--- a/sensor-listener/test.js
+++ b/sensor-listener/test.js
@@ -4,7 +4,7 @@ const Module = require('module');
 
 const originalRequire = Module.prototype.require;
 Module.prototype.require = function(request) {
-  if (request === '../config/config') {
+  if (request === './config/config') {
     return {
       MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION: 0,
       TEMPERATURE_THRESHOLD_IN_CELSIUS: 25,
@@ -88,7 +88,7 @@ function createMock() {
 async function testAbortWhenRedisUnreachable() {
   const originalRequire = Module.prototype.require;
   Module.prototype.require = function(request) {
-    if (request === '../config/config') {
+    if (request === './config/config') {
       return {
         INFLUX_HOST: 'influxdb',
         INFLUX_PORT: 8086,


### PR DESCRIPTION
## Summary
- update sensor listener modules to require config from local ./config directory
- adjust sensor-listener test mocks for new config path

## Testing
- `cd sensor-listener && npm test`

------
https://chatgpt.com/codex/tasks/task_e_6897ef76af288323b67f5e8387952c7f