### PR TITLE
chore: mount shared config directory in node services

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - /usr/src/app/node_modules
       - ./sensor-listener:/usr/src/app
+      - ./config:/usr/src/app/config
     depends_on:
       - influxdb
   weather-station:
@@ -32,6 +33,7 @@ services:
     volumes:
       - /usr/src/app/node_modules #bookmark volume (i.e. do NOT map to volume)
       - ./sensor-alerts:/usr/src/app
+      - ./config:/usr/src/app/config
     environment:
       TWILIO_ACCOUNT_SID: ${TWILIO_ACCOUNT_SID}
       TWILIO_AUTH_TOKEN: ${TWILIO_AUTH_TOKEN}


### PR DESCRIPTION
## Summary
- mount shared `config` folder into `sensor-listener` and `sensor-alerts` containers so configuration files remain available when the service directory is bind-mounted

## Testing
- `npm test` (sensor-alerts)
- `npm test` (sensor-listener)
- `docker compose version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*
- `docker-compose build sensor-alerts sensor-listener` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897f50cfd20832393145c569e5460be