### PR TITLE
Use shared config in sensor listener

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     volumes:
       - /usr/src/app/node_modules
       - ./sensor-listener:/usr/src/app
+      - ./config:/usr/src/config
     depends_on:
       - influxdb
   weather-station:

--- a/sensor-listener/common.js
+++ b/sensor-listener/common.js
@@ -1,7 +1,7 @@
 const Influx = require("influx");
 const { createClient } = require("redis");
 
-const config = require("./config/config");
+const config = require("../config/config");
 const influx = new Influx.InfluxDB({
   host: config.INFLUX_HOST,
   port: config.INFLUX_PORT,

--- a/sensor-listener/docker-compose.yml
+++ b/sensor-listener/docker-compose.yml
@@ -18,5 +18,6 @@ services:
     volumes:
       - /usr/src/app/node_modules #bookmark volume (i.e. do NOT map to volume)
       - .:/usr/src/app
+      - ../config:/usr/src/config
     ports:
       - "8080:8080"

--- a/sensor-listener/index.js
+++ b/sensor-listener/index.js
@@ -5,7 +5,7 @@ const timediff = require("timediff");
 const { z } = require("zod");
 const { influx, redisClient, redisPublisher } = require("./common");
 const waitForInfluxDb = require("../influxdb-ready").waitForInfluxDb;
-const config = require("./config/config");
+const config = require("../config/config");
 
 const {
   MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION,

--- a/sensor-listener/sensor-listener.dockerfile
+++ b/sensor-listener/sensor-listener.dockerfile
@@ -13,7 +13,7 @@ RUN npm install
 # RUN npm ci --only=production
 
 # Include shared configuration
-COPY config ./config
+COPY config/ /usr/src/config/
 
 # Bundle app source
 COPY sensor-listener ./

--- a/sensor-listener/test.js
+++ b/sensor-listener/test.js
@@ -4,7 +4,7 @@ const Module = require('module');
 
 const originalRequire = Module.prototype.require;
 Module.prototype.require = function(request) {
-  if (request === './config/config') {
+  if (request === '../config/config') {
     return {
       MINUTES_TO_WAIT_BEFORE_SENDING_NOTIFICATION: 0,
       TEMPERATURE_THRESHOLD_IN_CELSIUS: 25,
@@ -88,7 +88,7 @@ function createMock() {
 async function testAbortWhenRedisUnreachable() {
   const originalRequire = Module.prototype.require;
   Module.prototype.require = function(request) {
-    if (request === './config/config') {
+    if (request === '../config/config') {
       return {
         INFLUX_HOST: 'influxdb',
         INFLUX_PORT: 8086,


### PR DESCRIPTION
## Summary
- load sensor listener configuration from shared `config` directory
- update tests and docker setup to mount shared config

## Testing
- `cd sensor-listener && npm test`


------
https://chatgpt.com/codex/tasks/task_e_6897f500d50c8323bc8c87cd89acd756